### PR TITLE
Include request data as context

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,9 @@ export const sentry = (options: Options): IMiddlewareFunction => {
       return res
     } catch (err) {
       // Capture exception
-      captureException(err)
+      captureException(err, {
+        req: ctx.request,
+      })
 
       // Forward error
       if (options.forwardErrors) {


### PR DESCRIPTION
Hi there, thanks for this middleware.

Perhaps there's better solution, but it seems like `captureException` could include some request data along with the error object the same way that `Raven.requestHandler()` does. Raven will pick from a few things off a `request` parameter by default:

From https://docs.sentry.io/clients/node/usage/:

> **request**

> Alias: `req`. The `request` object associated with this event, from a Node http server, Express, Koa, or similar. Will be parsed for request details and user context from `request.user` if present. It will only pull out the data that’s handled by the server: `headers`, `method`, `host`, `protocol`, `url`, `query`, `cookies`, `body`, `ip` and `user`.