### PR TITLE
[Fix] renamed 'dns' to 'dsn'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ const resolvers = {
 }
 
 const sentryMiddleware = sentry({
-  dns: SENTRY_DNS
+  dsn: SENTRY_DSN
 })
 
 const server = GraphQLServer({


### PR DESCRIPTION
Sentry/Raven use term `DSN`