### PR TITLE
replace static `extras` option with a more dynamic `withScope` option

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   },
   "author": "Matic Zavadlal <matic.zavadlal@gmail.com>",
   "dependencies": {
-    "@sentry/node": "^4.3.2",
-    "lodash": "^4.17.11"
+    "@sentry/node": "^4.3.2"
   },
   "devDependencies": {
     "@types/lodash": "4.14.118",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1602,11 +1602,6 @@ lodash.toarray@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
   integrity sha1-JMS/zWsvuji/0FlNsRedjptlZWE=
 
-lodash@^4.17.11:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
-
 lodash@^4.17.4, lodash@^4.2.1:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"


### PR DESCRIPTION
Instead of adding string parsing using lodash, I've replaced the `extras` option with a `withScope` option.

The `withScope` option is a function that is called with the Sentry scope, the error, and the GraphQL context.

Using this option you can achieve the same as what previously was possible with the `extras` option + all other [context options](https://docs.sentry.io/enriching-error-data/context/?platform=javascript) Sentry provides.

I've also removed the `dsn` argument, since that simply is a property of the config object.

Example usage:

```ts
const sentryMiddleware = sentry<Context>({
  config: {
    dsn: process.env.SENTRY_DSN,
    environment: process.env.NODE_ENV,
    release: process.env.npm_package_version,
  },
  withScope: (scope, error, context) => {
    scope.setUser({
      id: context.authorization.userId,
    });
    scope.setExtra('body', context.request.body)
    scope.setExtra('origin', ctx.request.headers.origin)
    scope.setExtra('user-agent', context.request.headers['user-agent'])
  },
});
```